### PR TITLE
GitHub workflow: bump version of action checkout

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -10,7 +10,7 @@ jobs:
   linkChecker:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Link Checker
         uses: lycheeverse/lychee-action@master


### PR DESCRIPTION
This PR bumps action @checkout@ to latest version v3.