### PR TITLE
Fix the `Links` workflow

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -18,7 +18,7 @@ jobs:
           package-manager: pnpm@latest
 
       - name: Link Checker
-        uses: lycheeverse/lychee-action@1
+        uses: lycheeverse/lychee-action@v1
         with:
           args: --base dist --exclude-all-private dist
           fail: True


### PR DESCRIPTION
In https://github.com/lycheeverse/lycheeverse.github.io/pull/75, the ref was changed from `master` to `1`. However, that tag does not exist in https://github.com/lycheeverse/lychee-action/tags.

As a consequence, there has not been a single successful run of https://github.com/lycheeverse/lycheeverse.github.io/actions/workflows/links.yml since April 30th:

![image](https://github.com/lycheeverse/lycheeverse.github.io/assets/127790/a42a234c-dd05-489b-9778-f64ac2c4cddd)

Let's fix this by using the correct ref, the one that was most likely intended: https://github.com/lycheeverse/lychee-action/releases/tag/v1

Here is a successful run that was triggered on this PR branch: https://github.com/dscho/lycheeverse.github.io/actions/runs/9466960779/job/26079869528