### PR TITLE
fix: remove 403 status code from default config

### DIFF
--- a/src/content/docs/usage/cli.md
+++ b/src/content/docs/usage/cli.md
@@ -150,7 +150,7 @@ Options:
           separated list of accepted status codes. This example will accept 200, 201,
           202, 203, 204, 429, and 500 as valid status codes.
 
-          [default: 100..=103,200..=299,403..=403]
+          [default: 100..=103,200..=299]
 
       --include-fragments
           Enable the checking of fragments in links


### PR DESCRIPTION
As suggested in [#1157](https://github.com/lycheeverse/lychee/issues/1157#issuecomment-1941293819) and merged in [#1377](https://github.com/lycheeverse/lychee/pull/1377), the HTTP status code 403 was removed from the default configuration.

With this change, the default configuration in the docs will follow what is described at Commandline Parameters in the README of [lycheeverse/lychee](https://github.com/lycheeverse/lychee).