### PR TITLE
Fix documentation for exclude_paths

### DIFF
--- a/src/content/docs/recipes/excluding-paths.md
+++ b/src/content/docs/recipes/excluding-paths.md
@@ -9,7 +9,7 @@ You might think that you can just put the path in the [`.lycheeignore`](/recipes
 The `.lycheeignore` file is only used for excluding URLs, not paths.
 
 Instead, you can use the `--exclude-path` flag to exclude paths from being checked.
-Example: `--exclude-path node_modules` or `--exclude-path example\.(com|org)`.
+Example: `--exclude-path node_modules`
 
 Alternatively, you can also use the `exclude_path` key in the configuration file:
 
@@ -57,7 +57,6 @@ Exclude version control directories.
 ```bash
 lychee --exclude-path .git
 lychee --exclude-path .svn
-lychee --exclude-path "\.git|\.svn"
 ```
 
 ### Documentation and Non-Code Assets
@@ -66,14 +65,6 @@ Skip documentation and non-code related directories.
 
 ```bash
 lychee --exclude-path docs --exclude-path assets/images
-```
-
-### Backup Files
-
-Avoid checking backup files created by editors or tools.
-
-```bash
-lychee --exclude-path "*.bak"
 ```
 
 ### Logs and Databases

--- a/src/content/docs/recipes/excluding-paths.md
+++ b/src/content/docs/recipes/excluding-paths.md
@@ -17,12 +17,6 @@ Alternatively, you can also use the `exclude_path` key in the configuration file
 exclude_path = ["node_modules"]
 ```
 
-Regular expressions are also supported.
-
-```toml title="lychee.toml"
-exclude_path = ["node_modules", "^./dir/", ".*/dev/.*"]
-```
-
 [Here](https://github.com/mre/endler.dev/blob/50d8d5f90dbafa445c9455e420a40f8866f3e1c7/lychee.toml#L28) is an example config file.
 
 ## Examples


### PR DESCRIPTION
Remove examples of pattern matching / globs / regex. As these are unsupported.

See: https://github.com/lycheeverse/lychee/issues/1608 & https://github.com/lycheeverse/lychee/issues/470