### PR TITLE
Update docs related to `--root-dir`

### DIFF
--- a/src/content/docs/recipes/base-url.mdx
+++ b/src/content/docs/recipes/base-url.mdx
@@ -157,7 +157,7 @@ The trailing slash is crucial because it tells lychee whether `/docs` is a file 
 
 lychee can't automatically add the slash because both forms are valid - they just mean different things. For example, `https://example.com/docs` might be a single page, while `https://example.com/docs/` is its directory version. This distinction is part of how URLs work on the web.
 
-## --base-url vs --root-dir
+## `--base-url` vs `--root-dir`
 
 These solve different problems:
 
@@ -166,14 +166,14 @@ These solve different problems:
   - Use it when you care about your site's final URL structure
   - Helps validate relative links
 
-- [`--root-dir`](root-dir) is for file paths (like `./public/`)
+- [`--root-dir`](/recipes/root-dir) is for file paths (like `./public/`)
   - Use it to find files on your computer
   - Helps validate absolute paths
 
 You can use both together:
 
 ```bash
-lychee --base-url https://example.com/docs/ --root-dir ./public/ "public/**/*.html"
+lychee --base-url https://example.com/docs/ --root-dir $(pwd)/public/ "public/**/*.html"
 ```
 
 ## Troubleshooting

--- a/src/content/docs/recipes/root-dir.mdx
+++ b/src/content/docs/recipes/root-dir.mdx
@@ -7,7 +7,7 @@ import { Code } from "@astrojs/starlight/components";
 export const fileName = "index.html";
 export const fileLang = "html";
 
-## What Does --root-dir Do?
+## What Does `--root-dir` Do?
 
 The `--root-dir` parameter tells lychee where to look for files that start with `/`. Let's see an example:
 
@@ -32,7 +32,7 @@ lychee will look for:
 - `./public/about.html`
 - `./public/docs/guide.html`
 
-## When Do You Need --root-dir?
+## When Do You Need `--root-dir`?
 
 You need `--root-dir` when:
 
@@ -83,6 +83,23 @@ To check the links:
 lychee --root-dir "$(pwd)/public" "public/**/*.html"
 ```
 
+For GitHub Actions, please replace `$(pwd)` with [`${{ github.workspace }}`](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs#github-context):
+
+```yaml '${{ github.workspace }}'
+jobs:
+  check-links:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: lycheeverse/lychee-action@v2
+        with:
+          args: >-
+            --verbose
+            --no-progress
+            --root-dir "${{ github.workspace }}/public"
+            "public/**/*.html"
+```
+
 ### Documentation Site
 
 Many documentation sites use absolute paths for links:
@@ -102,7 +119,7 @@ To check these links:
 lychee --root-dir "$(pwd)" "docs/**/*.html"
 ```
 
-## The Difference Between --root-dir and --base-url
+## The Difference Between `--root-dir` and `--base-url`
 
 These parameters serve different purposes:
 
@@ -112,7 +129,7 @@ These parameters serve different purposes:
   - Must be an absolute filesystem path
   - Used when checking local files
 
-- [`--base-url`](base-url) is for resolving URLs
+- [`--base-url`](/recipes/base-url) is for resolving URLs
   - Must be a URL (like `https://example.com/docs/`)
   - Used when checking how links will work once deployed
   - Affects relative links (like `./guide.html`)


### PR DESCRIPTION
- Add docs on `github.workspace`

  See https://github.com/lycheeverse/lychee/issues/1606#issuecomment-2867105327.

- Surround `--root-dir` with back quotes

  Or `--` will turn into en dashes, which is weird…

- Fix broken links

  For example, the link `[…](base-url)` works in [`/recipes/root-dir`](https://lychee.cli.rs/recipes/root-dir#the-difference-between-root-dir-and-base-url), but does not work in [`/recipes/root-dir/`](https://lychee.cli.rs/recipes/root-dir/#the-difference-between-root-dir-and-base-url). (note the trailing slash)

  [Astro docs](https://docs.astro.build/en/basics/astro-pages/#link-between-pages):

  > Use a **URL path relative to your root domain** as your link, not a relative file path.

  So I change `base-url` to `/recipes/base-url`.
