### PR TITLE
Remove outdated text in "Check Links in Repository" recipe

### DIFF
--- a/src/content/docs/github_action_recipes/check-repository.mdx
+++ b/src/content/docs/github_action_recipes/check-repository.mdx
@@ -4,18 +4,6 @@ title: Check Links in Repository
 
 import CodeBlock from "../../../components/code.astro";
 
-This recipe demonstrates how to set up an automated workflow that will check all repository links once per day and create an issue in case of errors.
-
-The workflow is triggered in three scenarios:
-Manual trigger via workflow_dispatch
-Repository dispatch events
-Automated schedule (runs daily at 18:00 UTC)
-The workflow executes the following steps:
-Checks out the repository using actions/checkout@v5
-Runs the Lychee link checker (lycheeverse/lychee-action@v2) with fail: false to prevent workflow failure
-If any broken links are detected (exit code != 0), creates a new GitHub issue using peter-evans/create-issue-from-file@v6
-The issue contains the detailed report from ./lychee/out.md
-Issues are labeled with “report” and “automated issue”
-The workflow requires write permissions for issues to create automated reports when broken links are found.
+This recipe demonstrates how to set up an automated workflow that will check all repository links once per day.
 
 <CodeBlock file=".github/workflows/check-links.yml" />


### PR DESCRIPTION
the text is both outdated and formatted poorly on the website.

the code is automatically embedded from this repo's yml, and it should be short enough to be self explanatory. if more explanation is needed, i think it should be added as comments in the yml.

old text:
<img width="983" height="778" alt="image" src="https://github.com/user-attachments/assets/6dd0b410-aebd-490f-8d96-a0292c388dc1" />
