### PR TITLE
Redirect /introduction to /

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -4,6 +4,9 @@ import { defineConfig } from "astro/config";
 // https://astro.build/config
 export default defineConfig({
 	site: "https://lychee.cli.rs",
+	redirects: {
+		"/introduction": "/",
+	},
 	integrations: [
 		starlight({
 			expressiveCode: {


### PR DESCRIPTION
This URL [used to work](http://web.archive.org/web/20250822004333/https://lychee.cli.rs/introduction/) but doesn't anymore, so redirect it so [people who are using it](https://github.com/search?q=lychee.cli.rs%2Fintroduction&type=code) are redirected somewhere useful.

Closes #119