### PR TITLE
Allow required build scripts

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+allowBuilds:
+  esbuild: true
+  sharp: true


### PR DESCRIPTION
This resolves failures during the build step when using a newer pnpm version.

The resulting failure looked as follows:

```
[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: esbuild@0.25.12, sharp@0.34.5

Run "pnpm approve-builds" to pick which dependencies should be allowed to run scripts.
```