### PR TITLE
Fix pnpm dev commands on pnpm 9

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,5 +26,11 @@
 	},
 	"devDependencies": {
 		"@biomejs/biome": "^2.3.8"
+	},
+	"pnpm": {
+		"onlyBuiltDependencies": [
+			"esbuild",
+			"sharp"
+		]
 	}
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,0 @@
-allowBuilds:
-  esbuild: true
-  sharp: true


### PR DESCRIPTION
The pnpm-workspace.yaml added in #153 breaks pnpm 9: pnpm 9 treats the file as a workspace root and requires a `packages` field, so every pnpm command (including `make watch`) fails with `ERROR packages field missing or empty`.

Move the esbuild/sharp build-script approval to `package.json`'s `pnpm.onlyBuiltDependencies` (honored by both pnpm 9 and 10) and remove the workspace file.