### PR TITLE
Pin pnpm to 11.5.2

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -16,8 +16,6 @@ jobs:
 
       - name: Build site
         uses: withastro/action@v5
-        with:
-          package-manager: pnpm@11.5.2
 
       - name: Link Checker
         id: lychee

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Build site
         uses: withastro/action@v5
         with:
-          package-manager: pnpm@latest
+          package-manager: pnpm@11.5.2
 
       - name: Link Checker
         id: lychee

--- a/.github/workflows/check-pr-links.yml
+++ b/.github/workflows/check-pr-links.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Build site
         uses: withastro/action@v5
         with:
-          package-manager: pnpm@latest
+          package-manager: pnpm@11.5.2
 
       - name: Check links
         uses: lycheeverse/lychee-action@v2

--- a/.github/workflows/check-pr-links.yml
+++ b/.github/workflows/check-pr-links.yml
@@ -13,8 +13,6 @@ jobs:
 
       - name: Build site
         uses: withastro/action@v5
-        with:
-          package-manager: pnpm@11.5.2
 
       - name: Check links
         uses: lycheeverse/lychee-action@v2

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,8 +20,6 @@ jobs:
         uses: actions/checkout@v5
       - name: Install, build, and upload your site
         uses: withastro/action@v5
-        with:
-          package-manager: pnpm@11.5.2
 
   deploy:
     needs: build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install, build, and upload your site
         uses: withastro/action@v5
         with:
-          package-manager: pnpm@latest
+          package-manager: pnpm@11.5.2
 
   deploy:
     needs: build

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
 	"type": "module",
 	"version": "2025.07.16",
 	"private": true,
+	"packageManager": "pnpm@11.5.2",
 	"scripts": {
 		"dev": "astro dev",
 		"start": "astro dev",


### PR DESCRIPTION
Add `"packageManager": "pnpm@11.5.2"` to `package.json` and replace `pnpm@latest` with `pnpm@11.5.2` in the `withastro/action` workflows (deploy, check-links, check-pr-links). This pins pnpm to a single version so CI and local development agree and CI can't silently jump to a future major.

Background: CI installs with `pnpm@latest` while local environments may run older versions like pnpm 9, where the `pnpm-workspace.yaml` added in #153 (without a `packages:` field) causes every pnpm command to fail with `ERROR packages field missing or empty`, breaking `make watch`. The `allowBuilds:` config also requires pnpm 10.26+.

Supersedes #157.