### PR TITLE
Fix redirecting links

### DIFF
--- a/src/content/docs/continuous-integration/github.mdx
+++ b/src/content/docs/continuous-integration/github.mdx
@@ -177,6 +177,6 @@ to update the files.
 
 Here are the links to the blog posts which explain the process in more detail:
 
-- [Fixing my blog (part 2) - Broken links](https://david.gardiner.net.au/2022/04/blog-fix-part2.html)
-- [Fixing my blog (part 3) - Querying the Wayback Machine](https://david.gardiner.net.au/2022/04/blog-fix-part3.html)
-- [Fixing my blog (part 4) - Updating the files](https://david.gardiner.net.au/2022/04/blog-fix-part4.html)
+- [Fixing my blog (part 2) - Broken links](https://david.gardiner.net.au/2022/04/blog-fix-part2)
+- [Fixing my blog (part 3) - Querying the Wayback Machine](https://david.gardiner.net.au/2022/04/blog-fix-part3)
+- [Fixing my blog (part 4) - Updating the files](https://david.gardiner.net.au/2022/04/blog-fix-part4)

--- a/src/content/docs/guides/_config.md
+++ b/src/content/docs/guides/_config.md
@@ -2,7 +2,7 @@
 title: Configuration File
 ---
 
-The configuration file is a [TOML](https://toml.io) file that can be used to specify the options that are also available on the command line.
+The configuration file is a [TOML](https://toml.io/en/) file that can be used to specify the options that are also available on the command line.
 It comes in handy when you want to specify a lot of options, or when you want to configure lychee for continuous integration as part of a repository.
 
 By default `lychee.toml` is used if it exists in the current working directory.

--- a/src/content/docs/internals/credits.md
+++ b/src/content/docs/internals/credits.md
@@ -6,7 +6,7 @@ lychee would not be possible without the following projects.
 **Thanks a lot to all maintainers and contributors.**
 
 - [peter-evans/link-checker](https://github.com/peter-evans/link-checker): A GitHub action for link checking repository Markdown and HTML files. It served as the original template for lychee-action.
-- [raphlinus/pulldown-cmark](https://github.com/raphlinus/pulldown-cmark): A pull parser for CommonMark, written in Rust. It comes with a simple command-line tool, useful for rendering to HTML, and is also designed to be easy to use from as a library.
+- [pulldown-cmark/pulldown-cmark](https://github.com/pulldown-cmark/pulldown-cmark): A pull parser for CommonMark, written in Rust. It comes with a simple command-line tool, useful for rendering to HTML, and is also designed to be easy to use from as a library.
 - [reacherhq/check-if-mail-exists](https://github.com/reacherhq/check-if-email-exists): Check if an email address exists without sending any email.
 - [robinst/linkify](https://github.com/robinst/linkify): Rust library to find links such as URLs and email addresses in plain text, handling surrounding punctuation correctly.
 - [untitaker/html5gum](https://github.com/untitaker/html5gum): A WHATWG-compliant HTML5 tokenizer and tag soup parser

--- a/src/content/docs/internals/how-it-works.md
+++ b/src/content/docs/internals/how-it-works.md
@@ -36,6 +36,6 @@ We want the extractors to be as fast and memory-efficient as possible.
 
 Currently we support three main extractors:
 
-- [Pulldown CMark](https://github.com/raphlinus/pulldown-cmark) for Markdown files
+- [Pulldown CMark](https://github.com/pulldown-cmark/pulldown-cmark) for Markdown files
 - [html5gum](https://github.com/untitaker/html5gum) for HTML
 - [linkify](https://github.com/robinst/linkify) as a fallback for plaintext files and other unknown formats.

--- a/src/content/docs/internals/sponsors.md
+++ b/src/content/docs/internals/sponsors.md
@@ -25,7 +25,7 @@ Please head over to our [Open Collective](https://opencollective.com/lychee-coll
     </a>
     <p class="sponsor-description">
       NLnet is supporting the open internet since 1997. lychee received financial
-      support through the <a href="https://nlnet.nl/core">NGI0 Core Fund</a>,
+      support through the <a href="https://nlnet.nl/core/">NGI0 Core Fund</a>,
       established by NLnet with financial support from the European Commission's
       <a href="https://ngi.eu">Next Generation Internet</a> programme.
     </p>

--- a/src/content/docs/recipes/root-dir.mdx
+++ b/src/content/docs/recipes/root-dir.mdx
@@ -72,7 +72,7 @@ To check the links:
 lychee --root-dir public "public/**/*.html"
 ```
 
-For GitHub Actions, the working directory can be accessed with [`${{ github.workspace }}`](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs#github-context).
+For GitHub Actions, the working directory can be accessed with [`${{ github.workspace }}`](https://docs.github.com/en/actions/reference/workflows-and-actions/contexts#github-context).
 
 ### Documentation Site
 

--- a/src/content/docs/troubleshooting/custom-headers.md
+++ b/src/content/docs/troubleshooting/custom-headers.md
@@ -11,4 +11,4 @@ You can use that argument multiple times to add more headers.
 Or, you can accept all content/MIME types: `--header "accept=*/*"`.
 
 Learn more about the `Accept` header
-[over at MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept).
+[over at MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Accept).

--- a/src/content/docs/troubleshooting/rate-limits.mdx
+++ b/src/content/docs/troubleshooting/rate-limits.mdx
@@ -54,7 +54,7 @@ use a GitHub personal access token to circumvent this.
 When using `GITHUB_TOKEN`, the rate limit is **1,000 requests per hour per repository**.
 For requests to resources that belong to an enterprise account on GitHub.com,
 GitHub Enterprise Cloud's rate limit applies, and the limit is 15,000 requests
-per hour per repository. ([Source](https://docs.github.com/en/developers/apps/building-github-apps/rate-limits-for-github-apps))
+per hour per repository. ([Source](https://docs.github.com/en/apps/creating-github-apps/registering-a-github-app/rate-limits-for-github-apps))
 So using a token can greatly increase the number of requests you can make! 🚀
 :::
 

--- a/src/content/docs/troubleshooting/status-codes.md
+++ b/src/content/docs/troubleshooting/status-codes.md
@@ -3,7 +3,7 @@ title: Status Codes
 ---
 
 Some websites don't respond with a `200` (OK) status code. Instead they might
-send `204` (No Content), `206` (Partial Content), or [something else entirely](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/418).
+send `204` (No Content), `206` (Partial Content), or [something else entirely](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/418).
 
 In case you run into such issues you can work around that by providing a custom
 list of accepted status codes, such as `--accept 200,204,206`.


### PR DESCRIPTION
lychee flagged a number of links that returned 301/302 redirects. This updates them to their final destinations:

- MDN HTTP reference pages now live under `/Web/HTTP/Reference/` (`Accept` header, status 418)
- GitHub docs reorganized the workflow `contexts` page and the GitHub Apps rate-limit page
- `pulldown-cmark` moved from `raphlinus` to the `pulldown-cmark` org (2 references)
- `toml.io` -> `toml.io/en/`, `nlnet.nl/core` -> `nlnet.nl/core/`, and the David Gardiner blog posts dropped their `.html` suffix

Intentional/unavoidable redirects are left as-is: `docs.rs/lychee-lib` (redirects to the latest version), `github.com/settings/tokens` (login), and a `stackoverflow.com` short link.

Verified with a local `pnpm build` and a `lychee --max-redirects 0` re-check.